### PR TITLE
Update supported emulators list

### DIFF
--- a/docs/supported-emulators.md
+++ b/docs/supported-emulators.md
@@ -5,12 +5,10 @@ EmuDeck couldn't exist without the effort of all the teams working on these emul
 <div class="grid cards grid--5" markdown>
 - <a href="https://www.richwhitehouse.com/jaguar/" target="_blank"><figure markdown="span"><img src="/assets/emulators/bigpemu.png"><figcaption>BigPemu</figcaption></figure></a>
 - <a href="https://cemu.info/" target="_blank"><figure markdown="span"><img src="/assets/emulators/cemu.png"><figcaption>Cemu</figcaption></figure></a>
-- <a href="https://citra-emu.org/" target="_blank"><figure markdown="span"><img src="/assets/emulators/citra.png"><figcaption>Citra</figcaption></figure></a>
-- <a href="https://citron-emu.org/" target="_blank"><figure markdown="span"><img src="/assets/emulators/citron.png"><figcaption>Citron</figcaption></figure></a>
+- <a href="https://azahar-emu.org/" target="_blank"><figure markdown="span"><img src="/assets/emulators/azahar.png"><figcaption>Azahar</figcaption></figure></a>
 - <a href="https://dolphin-emu.org/" target="_blank"><figure markdown="span"><img src="/assets/emulators/dolphin.png"><figcaption>Dolphin</figcaption></figure></a>
 - <a href="https://www.duckstation.org/" target="_blank"><figure markdown="span"><img src="/assets/emulators/duckstation.png"><figcaption>DuckStation</figcaption></figure></a>
 - <a href="https://github.com/flyinghead/flycast" target="_blank"><figure markdown="span"><img src="/assets/emulators/flycast.png"><figcaption>Flycast</figcaption></figure></a>
-- <a href="#" target="_blank"><figure markdown="span"><img src="/assets/emulators/lime3ds.png"><figcaption>Lime3ds</figcaption></figure></a>
 - <a href="https://www.mamedev.org/" target="_blank"><figure markdown="span"><img src="/assets/emulators/mame.png"><figcaption>MAME</figcaption></figure></a>
 - <a href="https://melonds.kuribo64.net/" target="_blank"><figure markdown="span"><img src="/assets/emulators/melonds.png"><figcaption>melonDS</figcaption></figure></a>
 - <a href="https://mgba.io/" target="_blank"><figure markdown="span"><img src="/assets/emulators/mgba.png"><figcaption>mGBA</figcaption></figure></a>
@@ -21,14 +19,13 @@ EmuDeck couldn't exist without the effort of all the teams working on these emul
 - <a href="https://github.com/libretro/RetroArch/" target="_blank"><figure markdown="span"><img src="/assets/emulators/ra.png"><figcaption>RetroArch</figcaption></figure></a>
 - <a href="https://github.com/Rosalie241/RMG" target="_blank"><figure markdown="span"><img src="/assets/emulators/rmg.png"><figcaption>RMG</figcaption></figure></a>
 - <a href="https://rpcs3.net/" target="_blank"><figure markdown="span"><img src="/assets/emulators/rpcs3.png"><figcaption>RPCS3</figcaption></figure></a>
-- <a href="https://ryujinx.org/" target="_blank"><figure markdown="span"><img src="/assets/emulators/ryujinx.png"><figcaption>Ryujinx</figcaption></figure></a>
+- <a href="https://ryujinx.app/" target="_blank"><figure markdown="span"><img src="/assets/emulators/ryujinx.png"><figcaption>Ryujinx</figcaption></figure></a>
 - <a href="https://www.scummvm.org/" target="_blank"><figure markdown="span"><img src="/assets/emulators/scummvm.png"><figcaption>Scummvm</figcaption></figure></a>
 - <a href="https://www.shadps4.net/" target="_blank"><figure markdown="span"><img src="/assets/emulators/shadps4.png"><figcaption>Shadps4</figcaption></figure></a>
 - <a href="https://www.supermodel3.com/" target="_blank"><figure markdown="span"><img src="/assets/emulators/supermodel.png"><figcaption>Supermodel</figcaption></figure></a>
 - <a href="https://vita3k.org/" target="_blank"><figure markdown="span"><img src="/assets/emulators/vita3k.png"><figcaption>Vita3K</figcaption></figure></a>
 - <a href="https://xemu.app/" target="_blank"><figure markdown="span"><img src="/assets/emulators/xemu.png"><figcaption>Xemu</figcaption></figure></a>
 - <a href="https://xenia.jp/" target="_blank"><figure markdown="span"><img src="/assets/emulators/xenia.png"><figcaption>Xenia</figcaption></figure></a>
-- <a href="https://yuzu-emu.org/" target="_blank"><figure markdown="span"><img src="/assets/emulators/yuzu.png"><figcaption>Yuzu</figcaption></figure></a>
 </div>
 
 !!! info "Do you want us to add more emulators?"


### PR DESCRIPTION
Removed Citra, Citron, and Yuzu emulator links and added Azahar emulator link in replacement of Lime3DS. Updated Ryujinx link to the forked site as opposed to the dead link.

Note: Merging this PR requires the azahar.png logo file to be present.